### PR TITLE
Bump @babel/traverse and babel-eslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "@wordpress/notices": "^4.9.0",
                 "@wordpress/scripts": "^26.12.0",
                 "autoprefixer": "~10.4.19",
-                "babel-eslint": "^8.2.6",
+                "babel-eslint": "^10.1.0",
                 "babel-loader": "8.0.0",
                 "concurrently": "^6.2.0",
                 "cssnano": "4.1.11",
@@ -298,26 +298,6 @@
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-get-function-arity": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
-            "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/types": "7.0.0-beta.44"
-            }
-        },
-        "node_modules/@babel/helper-get-function-arity/node_modules/@babel/types": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-            "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-            "dev": true,
-            "dependencies": {
-                "esutils": "^2.0.2",
-                "lodash": "^4.2.0",
-                "to-fast-properties": "^2.0.0"
             }
         },
         "node_modules/@babel/helper-hoist-variables": {
@@ -8344,137 +8324,24 @@
             "dev": true
         },
         "node_modules/babel-eslint": {
-            "version": "8.2.6",
-            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
-            "integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+            "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
             "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "7.0.0-beta.44",
-                "@babel/traverse": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44",
-                "babylon": "7.0.0-beta.44",
-                "eslint-scope": "3.7.1",
-                "eslint-visitor-keys": "^1.0.0"
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.7.0",
+                "@babel/traverse": "^7.7.0",
+                "@babel/types": "^7.7.0",
+                "eslint-visitor-keys": "^1.0.0",
+                "resolve": "^1.12.0"
             },
             "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/babel-eslint/node_modules/@babel/code-frame": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-            "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
-            "dev": true,
-            "dependencies": {
-                "@babel/highlight": "7.0.0-beta.44"
-            }
-        },
-        "node_modules/babel-eslint/node_modules/@babel/generator": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
-            "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/types": "7.0.0-beta.44",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.2.0",
-                "source-map": "^0.5.0",
-                "trim-right": "^1.0.1"
-            }
-        },
-        "node_modules/babel-eslint/node_modules/@babel/helper-function-name": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
-            "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-get-function-arity": "7.0.0-beta.44",
-                "@babel/template": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44"
-            }
-        },
-        "node_modules/babel-eslint/node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
-            "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/types": "7.0.0-beta.44"
-            }
-        },
-        "node_modules/babel-eslint/node_modules/@babel/highlight": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-            "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.0"
-            }
-        },
-        "node_modules/babel-eslint/node_modules/@babel/template": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
-            "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
-            "dev": true,
-            "dependencies": {
-                "@babel/code-frame": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44",
-                "babylon": "7.0.0-beta.44",
-                "lodash": "^4.2.0"
-            }
-        },
-        "node_modules/babel-eslint/node_modules/@babel/traverse": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
-            "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/code-frame": "7.0.0-beta.44",
-                "@babel/generator": "7.0.0-beta.44",
-                "@babel/helper-function-name": "7.0.0-beta.44",
-                "@babel/helper-split-export-declaration": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44",
-                "babylon": "7.0.0-beta.44",
-                "debug": "^3.1.0",
-                "globals": "^11.1.0",
-                "invariant": "^2.2.0",
-                "lodash": "^4.2.0"
-            }
-        },
-        "node_modules/babel-eslint/node_modules/@babel/types": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-            "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-            "dev": true,
-            "dependencies": {
-                "esutils": "^2.0.2",
-                "lodash": "^4.2.0",
-                "to-fast-properties": "^2.0.0"
-            }
-        },
-        "node_modules/babel-eslint/node_modules/debug": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "^2.1.1"
-            }
-        },
-        "node_modules/babel-eslint/node_modules/eslint-scope": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-            "integrity": "sha512-ivpbtpUgg9SJS4TLjK7KdcDhqc/E3CGItsvQbBNLkNGUeMhd5qnJcryba/brESS+dg3vrLqPuc/UcS7jRJdN5A==",
-            "dev": true,
-            "dependencies": {
-                "esrecurse": "^4.1.0",
-                "estraverse": "^4.1.1"
+                "node": ">=6"
             },
-            "engines": {
-                "node": ">=4.0.0"
+            "peerDependencies": {
+                "eslint": ">= 4.12.1"
             }
         },
         "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
@@ -8485,21 +8352,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/babel-eslint/node_modules/estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/babel-eslint/node_modules/js-tokens": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
-            "dev": true
         },
         "node_modules/babel-jest": {
             "version": "29.7.0",
@@ -8756,18 +8608,6 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/babylon": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-            "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-            "dev": true,
-            "bin": {
-                "babylon": "bin/babylon.js"
-            },
-            "engines": {
-                "node": ">=4.2.0"
             }
         },
         "node_modules/balanced-match": {
@@ -16102,15 +15942,6 @@
             "integrity": "sha512-IMSCKVf0USrM/959vj3xac7s8f87sc+80Y/ipBzdKy4ifBv5Gsj2tZ41EAaURVg01QU71fYr77uA8Meh6kELbg==",
             "deprecated": "We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser",
             "dev": true
-        },
-        "node_modules/invariant": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-            "dev": true,
-            "dependencies": {
-                "loose-envify": "^1.0.0"
-            }
         },
         "node_modules/ip-address": {
             "version": "9.0.5",
@@ -28160,15 +27991,6 @@
                 "node": ">=0.8.0"
             }
         },
-        "node_modules/trim-right": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-            "integrity": "sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/truncate-utf8-bytes": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -30089,28 +29911,6 @@
             "requires": {
                 "@babel/template": "^7.22.15",
                 "@babel/types": "^7.23.0"
-            }
-        },
-        "@babel/helper-get-function-arity": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
-            "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "7.0.0-beta.44"
-            },
-            "dependencies": {
-                "@babel/types": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.2.0",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                }
             }
         },
         "@babel/helper-hoist-variables": {
@@ -35928,148 +35728,23 @@
             "dev": true
         },
         "babel-eslint": {
-            "version": "8.2.6",
-            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
-            "integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+            "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.44",
-                "@babel/traverse": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44",
-                "babylon": "7.0.0-beta.44",
-                "eslint-scope": "3.7.1",
-                "eslint-visitor-keys": "^1.0.0"
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.7.0",
+                "@babel/traverse": "^7.7.0",
+                "@babel/types": "^7.7.0",
+                "eslint-visitor-keys": "^1.0.0",
+                "resolve": "^1.12.0"
             },
             "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "7.0.0-beta.44"
-                    }
-                },
-                "@babel/generator": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "7.0.0-beta.44",
-                        "jsesc": "^2.5.1",
-                        "lodash": "^4.2.0",
-                        "source-map": "^0.5.0",
-                        "trim-right": "^1.0.1"
-                    }
-                },
-                "@babel/helper-function-name": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-get-function-arity": "7.0.0-beta.44",
-                        "@babel/template": "7.0.0-beta.44",
-                        "@babel/types": "7.0.0-beta.44"
-                    }
-                },
-                "@babel/helper-split-export-declaration": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "7.0.0-beta.44"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^3.0.0"
-                    }
-                },
-                "@babel/template": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "7.0.0-beta.44",
-                        "@babel/types": "7.0.0-beta.44",
-                        "babylon": "7.0.0-beta.44",
-                        "lodash": "^4.2.0"
-                    }
-                },
-                "@babel/traverse": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "7.0.0-beta.44",
-                        "@babel/generator": "7.0.0-beta.44",
-                        "@babel/helper-function-name": "7.0.0-beta.44",
-                        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
-                        "@babel/types": "7.0.0-beta.44",
-                        "babylon": "7.0.0-beta.44",
-                        "debug": "^3.1.0",
-                        "globals": "^11.1.0",
-                        "invariant": "^2.2.0",
-                        "lodash": "^4.2.0"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.2.0",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "debug": {
-                    "version": "3.2.7",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "eslint-scope": {
-                    "version": "3.7.1",
-                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-                    "integrity": "sha512-ivpbtpUgg9SJS4TLjK7KdcDhqc/E3CGItsvQbBNLkNGUeMhd5qnJcryba/brESS+dg3vrLqPuc/UcS7jRJdN5A==",
-                    "dev": true,
-                    "requires": {
-                        "esrecurse": "^4.1.0",
-                        "estraverse": "^4.1.1"
-                    }
-                },
                 "eslint-visitor-keys": {
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
                     "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-                    "dev": true
-                },
-                "estraverse": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-                    "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-                    "dev": true
-                },
-                "js-tokens": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-                    "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
                     "dev": true
                 }
             }
@@ -36266,12 +35941,6 @@
                 "babel-plugin-jest-hoist": "^29.6.3",
                 "babel-preset-current-node-syntax": "^1.0.0"
             }
-        },
-        "babylon": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-            "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-            "dev": true
         },
         "balanced-match": {
             "version": "1.0.2",
@@ -41881,15 +41550,6 @@
             "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.8.1.tgz",
             "integrity": "sha512-IMSCKVf0USrM/959vj3xac7s8f87sc+80Y/ipBzdKy4ifBv5Gsj2tZ41EAaURVg01QU71fYr77uA8Meh6kELbg==",
             "dev": true
-        },
-        "invariant": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-            "dev": true,
-            "requires": {
-                "loose-envify": "^1.0.0"
-            }
         },
         "ip-address": {
             "version": "9.0.5",
@@ -51097,12 +50757,6 @@
                     "dev": true
                 }
             }
-        },
-        "trim-right": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-            "integrity": "sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==",
-            "dev": true
         },
         "truncate-utf8-bytes": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "@wordpress/notices": "^4.9.0",
         "@wordpress/scripts": "^26.12.0",
         "autoprefixer": "~10.4.19",
-        "babel-eslint": "^8.2.6",
+        "babel-eslint": "^10.1.0",
         "babel-loader": "8.0.0",
         "concurrently": "^6.2.0",
         "cssnano": "4.1.11",


### PR DESCRIPTION
Bumps [@babel/traverse](https://github.com/babel/babel/tree/HEAD/packages/babel-traverse) to 7.24.5 and updates ancestor dependency [babel-eslint](https://github.com/babel/babel-eslint). These dependencies need to be updated together.


Updates `@babel/traverse` from 7.0.0-beta.44 to 7.24.5
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/commits/v7.24.5/packages/babel-traverse)

Updates `babel-eslint` from 8.2.6 to 10.1.0
- [Release notes](https://github.com/babel/babel-eslint/releases)
- [Commits](https://github.com/babel/babel-eslint/compare/v8.2.6...v10.1.0)

---
updated-dependencies:
- dependency-name: "@babel/traverse" dependency-type: indirect
- dependency-name: babel-eslint dependency-type: direct:development ...